### PR TITLE
chore!: drop support for node 16

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
 	env: {
-		es2021: true,
+		es2022: true,
 		node: true,
 	},
 	extends: [
@@ -14,7 +14,7 @@ module.exports = {
 		"prettier",
 	],
 	parserOptions: {
-		ecmaVersion: 2021,
+		ecmaVersion: 2022,
 	},
 	plugins: [
 		"import",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         if: github.event.pull_request.draft == false
         strategy:
             matrix:
-                node-version: [16, 18]
+                node-version: [18]
                 # Only Linux containers support services currently
                 os: [ubuntu-latest]
         runs-on: ${{ matrix.os }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:18-alpine
 
 # Workdir
 WORKDIR /usr/app

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A case study detailing the benefits of this API (and calling workflows) can be f
 
 ## Prerequisites
 
--   [Node.js](https://nodejs.org/en/) >=16.0.0 (if running outside of Docker)
+-   [Node.js](https://nodejs.org/en/) >=18.12.1 (if running outside of Docker)
 -   [SQL Server](https://microsoft.com/en-gb/sql-server/sql-server-downloads) >=13.0.1601.5 or [PostgreSQL](https://postgresql.org/download/) >=9.4 (either as services/instances or Docker containers)
 
 ## Setup

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
 				"prettier": "^2.7.1"
 			},
 			"engines": {
-				"node": ">=16.0.0"
+				"node": ">=18.12.1"
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 	"license": "MIT",
 	"author": "Frazer Smith <frazer.smith@ydh.nhs.uk>",
 	"engines": {
-		"node": ">=16.0.0"
+		"node": ">=18.12.1"
 	},
 	"scripts": {
 		"benchmark": "autocannon -a 1000 \"http://0.0.0.0:3000/admin/healthcheck\"",


### PR DESCRIPTION
BREAKING CHANGE: minimum required version of node increased from 16.0.0 to 18.12.1

Node 16 becomes EOL in September 2023, which is the same time that [Yeovil District Hospital NHS Foundation Trust is due to merge with Somerset NHS Foundation Trust](https://yeovilhospital.co.uk/better-care-for-local-people-the-merger-of-yeovil-hospital-nhs-foundation-trust-with-somerset-nhs-foundation-trust/). Development will be focused on the merger at that point in time, so this PR preemptively drops support to reduce work load in the future.